### PR TITLE
handlehandlekeydown

### DIFF
--- a/components/App.tsx
+++ b/components/App.tsx
@@ -43,15 +43,19 @@ const App = () => {
             setsDroppableSnapshot: DroppableStateSnapshot,
           ) => (
             <div
-              className="set-droppable-container"
+              className={`set-droppable-container ${
+                setsDroppableSnapshot.isDraggingOver ? 'dragging-over' : ''
+              }`}
               {...setsDroppableProvided.droppableProps}
               ref={setsDroppableProvided.innerRef}
-              style={{
-                backgroundColor: setsDroppableSnapshot.isDraggingOver ? '#f5f5f5' : 'inherit',
-              }}
             >
               {currentView.setIds.map((setId, setIndex) => (
-                <DraggableSet key={setId} setId={setId} setIndex={setIndex} />
+                <DraggableSet
+                  key={setId}
+                  setId={setId}
+                  setIndex={setIndex}
+                  isDraggingOverView={setsDroppableSnapshot.isDraggingOver}
+                />
               ))}
               {setsDroppableProvided.placeholder}
               <button type="button" className="add-set" onClick={addSet}>
@@ -86,6 +90,10 @@ const App = () => {
         }
         .set-droppable-container {
           transition: all 240ms ease-out;
+          background-color: white;
+        }
+        .dragging-over {
+          background-color: #f5f5f5;
         }
         .logout {
           position: fixed;

--- a/components/context/ViewContextProvider.tsx
+++ b/components/context/ViewContextProvider.tsx
@@ -12,6 +12,8 @@ interface IProps {
   setItems: React.Dispatch<React.SetStateAction<Item>>;
   itemRefs: { [id: string]: RefObject<HTMLInputElement> };
   setItemRefs: React.Dispatch<React.SetStateAction<RefObject<HTMLInputElement>>>;
+  handleRefs: { [id: string]: RefObject<HTMLInputElement> };
+  setHandleRefs: React.Dispatch<React.SetStateAction<RefObject<HTMLInputElement>>>;
   focussedId: string;
   setFocussedId: React.Dispatch<React.SetStateAction<string>>;
 }
@@ -24,6 +26,7 @@ export const ViewContextProvider = ({ children }) => {
   const [sets, setSets] = useState<{ [id: string]: Set }>({});
   const [items, setItems] = useState<{ [id: string]: Item }>({});
   const [itemRefs, setItemRefs] = useState<{ [id: string]: RefObject<HTMLInputElement> }>({});
+  const [handleRefs, setHandleRefs] = useState<{ [id: string]: RefObject<HTMLInputElement> }>({});
   const [focussedId, setFocussedId] = useState<string>('');
 
   const value = {
@@ -35,6 +38,8 @@ export const ViewContextProvider = ({ children }) => {
     setItems,
     itemRefs,
     setItemRefs,
+    handleRefs,
+    setHandleRefs,
     focussedId,
     setFocussedId,
   };

--- a/components/draggables/DraggableItem.tsx
+++ b/components/draggables/DraggableItem.tsx
@@ -43,7 +43,7 @@ const DraggableItem = ({
   const set = sets[setId];
   const item = items[itemId];
   const itemRef = useRef<HTMLInputElement>();
-  const handleRef = useRef<HTMLInputElement>();
+  const handleRef = useRef<HTMLDivElement>();
   const isFirstItem = index === 0;
   const isLastItem = index === set.itemIds.length - 1;
   const prevItemId = set.itemIds[index - 1];

--- a/components/draggables/DraggableItem.tsx
+++ b/components/draggables/DraggableItem.tsx
@@ -17,7 +17,7 @@ interface IProps {
   addItem: () => void;
   deleteSet: () => void;
   addItemRef: RefObject<HTMLButtonElement>;
-  isDraggingOver: boolean;
+  isDraggingOverSet: boolean;
 }
 
 const DraggableItem = ({
@@ -27,7 +27,7 @@ const DraggableItem = ({
   addItem,
   deleteSet,
   addItemRef,
-  isDraggingOver,
+  isDraggingOverSet,
 }: IProps) => {
   const {
     sets,
@@ -139,7 +139,7 @@ const DraggableItem = ({
         ) => (
           <div
             className={`item ${itemsDraggableSnapshot.isDragging ? 'dragging' : ''} ${
-              isDraggingOver ? 'dragging-over' : ''
+              isDraggingOverSet ? 'dragging-over-set' : ''
             }`}
             {...itemsDraggableProvided.draggableProps}
             ref={itemsDraggableProvided.innerRef}
@@ -201,7 +201,7 @@ const DraggableItem = ({
         .item:hover .handle {
           opacity: 1;
         }
-        .dragging-over:hover .handle {
+        .dragging-over-set:hover .handle {
           opacity: 0;
         }
         .delete-item {

--- a/components/draggables/DraggableSet.tsx
+++ b/components/draggables/DraggableSet.tsx
@@ -120,7 +120,7 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
                         ref={addItemRef}
                         onKeyDown={handleAddItemKeydown}
                         type="button"
-                        className="add-item red"
+                        className="add-item"
                         onClick={addItem}
                       >
                         + Add

--- a/components/draggables/DraggableSet.tsx
+++ b/components/draggables/DraggableSet.tsx
@@ -94,13 +94,11 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
               ) => {
                 return (
                   <div
-                    className="item-droppable-container"
+                    className={`item-droppable-container ${
+                      itemsDroppableSnapshot.isDraggingOver ? 'dragging-over' : ''
+                    } ${setsDraggableSnapshot.isDragging ? 'dragging' : ''}`}
                     ref={itemsDroppableProvided.innerRef}
                     {...itemsDroppableProvided.droppableProps}
-                    style={{
-                      boxShadow: setsDraggableSnapshot.isDragging ? '0 0 15px rgba(0,0,0,.3)' : '',
-                      backgroundColor: itemsDroppableSnapshot.isDraggingOver ? '#f5f5f5' : 'white',
-                    }}
                   >
                     {set.itemIds.map((itemId, index) => {
                       return (
@@ -112,6 +110,7 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
                           addItem={addItem}
                           deleteSet={deleteSet}
                           addItemRef={addItemRef}
+                          isDraggingOver={itemsDroppableSnapshot.isDraggingOver}
                         />
                       );
                     })}
@@ -121,7 +120,7 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
                         ref={addItemRef}
                         onKeyDown={handleAddItemKeydown}
                         type="button"
-                        className="add-item"
+                        className="add-item red"
                         onClick={addItem}
                       >
                         + Add
@@ -159,6 +158,13 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
         }
         .item-droppable-container {
           transition: all 240ms ease-out;
+          background-color: white;
+        }
+        .dragging {
+          box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
+        }
+        .dragging-over {
+          background-color: #f5f5f5;
         }
         .delete-set {
           cursor: pointer;

--- a/components/draggables/DraggableSet.tsx
+++ b/components/draggables/DraggableSet.tsx
@@ -22,9 +22,10 @@ export enum DragDropType {
 interface IProps {
   setIndex: number;
   setId: string;
+  isDraggingOverView: boolean;
 }
 
-const DraggableSet = ({ setId, setIndex }: IProps) => {
+const DraggableSet = ({ setId, setIndex, isDraggingOverView }: IProps) => {
   const addItemRef = useRef();
 
   const {
@@ -82,7 +83,7 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
           setsDraggableSnapshot: DraggableStateSnapshot,
         ) => (
           <div
-            className="set"
+            className={`set ${isDraggingOverView ? 'dragging-over-view' : ''}`}
             {...setsDraggableProvided.draggableProps}
             ref={setsDraggableProvided.innerRef}
           >
@@ -95,7 +96,7 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
                 return (
                   <div
                     className={`item-droppable-container ${
-                      itemsDroppableSnapshot.isDraggingOver ? 'dragging-over' : ''
+                      itemsDroppableSnapshot.isDraggingOver ? 'dragging-over-set' : ''
                     } ${setsDraggableSnapshot.isDragging ? 'dragging' : ''}`}
                     ref={itemsDroppableProvided.innerRef}
                     {...itemsDroppableProvided.droppableProps}
@@ -110,7 +111,7 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
                           addItem={addItem}
                           deleteSet={deleteSet}
                           addItemRef={addItemRef}
-                          isDraggingOver={itemsDroppableSnapshot.isDraggingOver}
+                          isDraggingOverSet={itemsDroppableSnapshot.isDraggingOver}
                         />
                       );
                     })}
@@ -156,6 +157,9 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
         .set:hover .set-handle {
           opacity: 1;
         }
+        .dragging-over-view:hover .set-handle {
+          opacity: 0;
+        }
         .item-droppable-container {
           transition: all 240ms ease-out;
           background-color: white;
@@ -163,7 +167,7 @@ const DraggableSet = ({ setId, setIndex }: IProps) => {
         .dragging {
           box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
         }
-        .dragging-over {
+        .dragging-over-set {
           background-color: #f5f5f5;
         }
         .delete-set {


### PR DESCRIPTION
focusされるhandleをarrowkeyで移動できるようにした
handlehandlekeydown 

pointerでドラッグアンドドロップしてるとき他のitemにhoverが発火しちゃうのを防いだ